### PR TITLE
Speed up FragmentRemoval and ConeClustering

### DIFF
--- a/include/LCContentFast.h
+++ b/include/LCContentFast.h
@@ -11,6 +11,7 @@
 #include "LCContentFast/CaloHitPreparationAlgorithmFast.h"
 #include "LCContentFast/ConeClusteringAlgorithmFast.h"
 #include "LCContentFast/MainFragmentRemovalAlgorithmFast.h"
+#include "LCContentFast/NeutralFragmentRemovalAlgorithmFast.h"
 #include "LCContentFast/SoftClusterMergingAlgorithmFast.h"
 #include "LCContentFast/TrackClusterAssociationAlgorithmFast.h"
 
@@ -24,6 +25,7 @@ public:
         d("CaloHitPreparationFast",                 lc_content_fast::CaloHitPreparationAlgorithm::Factory)                      \
         d("ConeClusteringFast",                     lc_content_fast::ConeClusteringAlgorithm::Factory)                          \
         d("MainFragmentRemovalFast",                lc_content_fast::MainFragmentRemovalAlgorithm::Factory)                     \
+        d("NeutralFragmentRemovalFast",             lc_content_fast::NeutralFragmentRemovalAlgorithm::Factory)                  \
         d("SoftClusterMergingFast",                 lc_content_fast::SoftClusterMergingAlgorithm::Factory)                      \
         d("TrackClusterAssociationFast",            lc_content_fast::TrackClusterAssociationAlgorithm::Factory)
 

--- a/include/LCContentFast.h
+++ b/include/LCContentFast.h
@@ -12,6 +12,7 @@
 #include "LCContentFast/ConeClusteringAlgorithmFast.h"
 #include "LCContentFast/MainFragmentRemovalAlgorithmFast.h"
 #include "LCContentFast/NeutralFragmentRemovalAlgorithmFast.h"
+#include "LCContentFast/PhotonFragmentRemovalAlgorithmFast.h"
 #include "LCContentFast/SoftClusterMergingAlgorithmFast.h"
 #include "LCContentFast/TrackClusterAssociationAlgorithmFast.h"
 
@@ -26,6 +27,7 @@ public:
         d("ConeClusteringFast",                     lc_content_fast::ConeClusteringAlgorithm::Factory)                          \
         d("MainFragmentRemovalFast",                lc_content_fast::MainFragmentRemovalAlgorithm::Factory)                     \
         d("NeutralFragmentRemovalFast",             lc_content_fast::NeutralFragmentRemovalAlgorithm::Factory)                  \
+        d("PhotonFragmentRemovalFast",              lc_content_fast::PhotonFragmentRemovalAlgorithm::Factory)                   \
         d("SoftClusterMergingFast",                 lc_content_fast::SoftClusterMergingAlgorithm::Factory)                      \
         d("TrackClusterAssociationFast",            lc_content_fast::TrackClusterAssociationAlgorithm::Factory)
 

--- a/include/LCContentFast/ConeClusteringAlgorithmFast.h
+++ b/include/LCContentFast/ConeClusteringAlgorithmFast.h
@@ -39,6 +39,7 @@ public:
 };
 
 typedef std::vector<const pandora::CaloHit *> CustomSortedCaloHitList;
+typedef std::unordered_map<const pandora::Cluster *, const pandora::CaloHit * > ClusterListWithNearestHit;
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -128,7 +129,7 @@ private:
      *  @param  genericDistance to receive the generic distance
      */
     pandora::StatusCode GetGenericDistanceToHit(const pandora::Cluster *const pCluster, const pandora::CaloHit *const pCaloHit,
-        const unsigned int searchLayer, const ClusterFitResultMap &clusterFitResultMap, float &genericDistance) const;
+        const unsigned int searchLayer, const ClusterFitResultMap &clusterFitResultMap, float &genericDistance, const pandora::CaloHit *const nearestHit) const;
 
     /**
      *  @brief  Get the generic distance between a calo hit and a cluster in the same pseudo layer
@@ -138,7 +139,7 @@ private:
      *  @param  distance to receive the distance
      */
     pandora::StatusCode GetDistanceToHitInSameLayer(const pandora::CaloHit *const pCaloHit, const pandora::CaloHitList *const pCaloHitList,
-        float &distance) const;
+        float &distance, const pandora::CaloHit *const nearestHit) const;
 
     /**
      *  @brief  Get the smallest cone approach distance between a calo hit and all the hits in a cluster, using a specified

--- a/include/LCContentFast/ConeClusteringAlgorithmFast.h
+++ b/include/LCContentFast/ConeClusteringAlgorithmFast.h
@@ -129,7 +129,7 @@ private:
      *  @param  genericDistance to receive the generic distance
      */
     pandora::StatusCode GetGenericDistanceToHit(const pandora::Cluster *const pCluster, const pandora::CaloHit *const pCaloHit,
-        const unsigned int searchLayer, const ClusterFitResultMap &clusterFitResultMap, float &genericDistance, const pandora::CaloHit *const nearestHit) const;
+        const unsigned int searchLayer, const ClusterFitResultMap &clusterFitResultMap, float &genericDistance, const pandora::CaloHit *const nearestHit, bool checkedNN) const;
 
     /**
      *  @brief  Get the generic distance between a calo hit and a cluster in the same pseudo layer
@@ -139,7 +139,7 @@ private:
      *  @param  distance to receive the distance
      */
     pandora::StatusCode GetDistanceToHitInSameLayer(const pandora::CaloHit *const pCaloHit, const pandora::CaloHitList *const pCaloHitList,
-        float &distance, const pandora::CaloHit *const nearestHit) const;
+        float &distance, const pandora::CaloHit *const nearestHit, bool checkedNN) const;
 
     /**
      *  @brief  Get the smallest cone approach distance between a calo hit and all the hits in a cluster, using a specified

--- a/include/LCContentFast/NeutralFragmentRemovalAlgorithmFast.h
+++ b/include/LCContentFast/NeutralFragmentRemovalAlgorithmFast.h
@@ -1,0 +1,220 @@
+/**
+ *  @file   LCContent/include/LCFragmentRemoval/NeutralFragmentRemovalAlgorithm.h
+ * 
+ *  @brief  Header file for the neutral fragment removal algorithm class.
+ * 
+ *  $Log: $
+ */
+#ifndef LC_NEUTRAL_FRAGMENT_REMOVAL_ALGORITHM_FAST_H
+#define LC_NEUTRAL_FRAGMENT_REMOVAL_ALGORITHM_FAST_H 1
+
+#include "Pandora/Algorithm.h"
+
+#include "LCContentFast/FragmentRemovalHelperFast.h"
+
+namespace lc_content_fast
+{
+
+/**
+ *  @brief  NeutralClusterContact class, describing the interactions and proximity between parent and daughter candidate clusters
+ */
+class NeutralClusterContact : public ClusterContact
+{
+public:
+    /**
+     *  @brief  Parameters class
+     */
+    class Parameters : public ClusterContact::Parameters
+    {
+    public:
+        float           m_coneCosineHalfAngle2;         ///< Cosine half angle for second cone comparison in cluster contact object
+        float           m_coneCosineHalfAngle3;         ///< Cosine half angle for third cone comparison in cluster contact object
+    };
+
+    /**
+     *  @brief  Constructor
+     * 
+     *  @param  pandora the associated pandora instance
+     *  @param  pDaughterCluster address of the daughter candidate cluster
+     *  @param  pParentCluster address of the parent candidate cluster
+     *  @param  parameters the cluster contact parameters
+     */
+    NeutralClusterContact(const pandora::Pandora &pandora, const pandora::Cluster *const pDaughterCluster, const pandora::Cluster *const pParentCluster,
+        const Parameters &parameters);
+
+    /**
+     *  @brief  Get the fraction of daughter hits that lie within specified cone 2 along parent direction
+     * 
+     *  @return The daughter cone fraction
+     */
+    float GetConeFraction2() const;
+
+    /**
+     *  @brief  Get the fraction of daughter hits that lie within specified cone 3 along parent direction
+     * 
+     *  @return The daughter cone fraction
+     */
+    float GetConeFraction3() const;
+
+private:
+    float               m_coneFraction2;                ///< Fraction of daughter hits that lie within specified cone 2 along parent direction
+    float               m_coneFraction3;                ///< Fraction of daughter hits that lie within specified cone 3 along parent direction
+};
+
+typedef std::vector<NeutralClusterContact> NeutralClusterContactVector;
+typedef std::map<const pandora::Cluster *, NeutralClusterContactVector> NeutralClusterContactMap;
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+/**
+ *  @brief  NeutralFragmentRemovalAlgorithm class
+ */
+class NeutralFragmentRemovalAlgorithm : public pandora::Algorithm
+{
+public:
+    /**
+     *  @brief  Factory class for instantiating algorithm
+     */
+    class Factory : public pandora::AlgorithmFactory
+    {
+    public:
+        pandora::Algorithm *CreateAlgorithm() const;
+    };
+
+    /**
+     *  @brief Default constructor
+     */
+    NeutralFragmentRemovalAlgorithm();
+
+private:
+    pandora::StatusCode Run();
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    /**
+     *  @brief  Get cluster contact map, linking each daughter candidate cluster to a list of parent candidates and describing
+     *          the proximity/contact between each pairing
+     * 
+     *  @param  isFirstPass whether this is the first call to GetNeutralClusterContactMap
+     *  @param  affectedClusters list of those clusters affected by previous cluster merging, for which contact details must be updated
+     *  @param  neutralClusterContactMap to receive the populated cluster contact map
+     */
+    pandora::StatusCode GetNeutralClusterContactMap(bool &isFirstPass, const pandora::ClusterList &affectedClusters,
+        NeutralClusterContactMap &neutralClusterContactMap) const;
+
+    /**
+     *  @brief  Whether candidate daughter cluster can be considered as photon-like
+     * 
+     *  @param  pDaughterCluster address of the candidate daughter cluster
+     * 
+     *  @return boolean
+     */
+    bool IsPhotonLike(const pandora::Cluster *const pDaughterCluster) const;
+
+    /**
+     *  @brief  Whether candidate parent and daughter clusters are sufficiently in contact to warrant further investigation
+     * 
+     *  @param  neutralClusterContact the cluster contact
+     * 
+     *  @return boolean
+     */
+    bool PassesClusterContactCuts(const NeutralClusterContact &neutralClusterContact) const;
+
+    /**
+     *  @brief  Find the best candidate parent and daughter clusters for fragment removal merging
+     * 
+     *  @param  neutralClusterContactMap the populated cluster contact map
+     *  @param  pBestParentCluster to receive the address of the best parent cluster candidate
+     *  @param  pBestDaughterCluster to receive the address of the best daughter cluster candidate
+     */
+    pandora::StatusCode GetClusterMergingCandidates(const NeutralClusterContactMap &neutralClusterContactMap, const pandora::Cluster *&pBestParentCluster,
+        const pandora::Cluster *&pBestDaughterCluster) const;
+
+    /**
+     *  @brief  Get a measure of the evidence for merging the parent and daughter candidate clusters
+     * 
+     *  @param  neutralClusterContact the cluster contact details for parent/daughter candidate merge
+     * 
+     *  @return the evidence
+     */
+    float GetEvidenceForMerge(const NeutralClusterContact &neutralClusterContact) const;
+
+    /**
+     *  @brief  Get the list of clusters for which cluster contact information will be affected by a specified cluster merge
+     * 
+     *  @param  neutralClusterContactMap the cluster contact map
+     *  @param  pBestParentCluster address of the parent cluster to be merged
+     *  @param  pBestDaughterCluster address of the daughter cluster to be merged
+     *  @param  affectedClusters to receive the list of affected clusters
+     */
+    pandora::StatusCode GetAffectedClusters(const NeutralClusterContactMap &neutralClusterContactMap, const pandora::Cluster *const pBestParentCluster,
+        const pandora::Cluster *const pBestDaughterCluster, pandora::ClusterList &affectedClusters) const;
+
+    typedef NeutralClusterContact::Parameters ContactParameters;
+    ContactParameters   m_contactParameters;                        ///< The neutral cluster contact parameters
+
+    unsigned int        m_nMaxPasses;                               ///< Maximum number of passes over cluster contact information
+
+    unsigned int        m_minDaughterCaloHits;                      ///< Min number of calo hits in daughter candidate clusters
+    float               m_minDaughterHadronicEnergy;                ///< Min hadronic energy for daughter candidate clusters
+
+    unsigned int        m_photonLikeMaxInnerLayer;                  ///< Max inner layer to identify daughter cluster as photon-like
+    float               m_photonLikeMinDCosR;                       ///< Max radial direction cosine to identify daughter as photon-like
+    float               m_photonLikeMaxShowerStart;                 ///< Max shower profile start to identify daughter as photon-like
+    float               m_photonLikeMaxProfileDiscrepancy;          ///< Max shower profile discrepancy to identify daughter as photon-like
+
+    float               m_contactCutMaxDistance;                    ///< Max distance between closest hits to store cluster contact info
+    unsigned int        m_contactCutNLayers;                        ///< Number of contact layers to store cluster contact info
+    float               m_contactCutConeFraction1;                  ///< Cone fraction 1 value to store cluster contact info
+    float               m_contactCutCloseHitFraction1;              ///< Close hit fraction 1 value to store cluster contact info
+    float               m_contactCutCloseHitFraction2;              ///< Close hit fraction 2 value to store cluster contact info
+    float               m_contactCutNearbyDistance;                 ///< Distance between closest hits to mark clusters as nearby
+    float               m_contactCutNearbyCloseHitFraction2;        ///< Close hit fraction 2 in nearby hits to store cluster contact info
+
+    unsigned int        m_contactEvidenceNLayers1;                  ///< Contact evidence n layers cut 1
+    unsigned int        m_contactEvidenceNLayers2;                  ///< Contact evidence n layers cut 2
+    unsigned int        m_contactEvidenceNLayers3;                  ///< Contact evidence n layers cut 3
+    float               m_contactEvidence1;                         ///< Contact evidence contribution 1
+    float               m_contactEvidence2;                         ///< Contact evidence contribution 2
+    float               m_contactEvidence3;                         ///< Contact evidence contribution 3
+
+    float               m_coneEvidenceFraction1;                    ///< Cone fraction 1 value required for cone evidence contribution
+    float               m_coneEvidenceFineGranularityMultiplier;    ///< Cone evidence multiplier for fine granularity daughter clusters
+
+    float               m_distanceEvidence1;                        ///< Offset for distance evidence contribution 1
+    float               m_distanceEvidence1d;                       ///< Denominator for distance evidence contribution 1
+    float               m_distanceEvidenceCloseFraction1Multiplier; ///< Distance evidence multiplier for close hit fraction 1
+    float               m_distanceEvidenceCloseFraction2Multiplier; ///< Distance evidence multiplier for close hit fraction 2
+
+    float               m_contactWeight;                            ///< Weight for layers in contact evidence
+    float               m_coneWeight;                               ///< Weight for cone extrapolation evidence
+    float               m_distanceWeight;                           ///< Weight for distance of closest approach evidence
+
+    float               m_minEvidence;                              ///< Min evidence before parent/daughter candidates can be merged
+};
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline float NeutralClusterContact::GetConeFraction2() const
+{
+    return m_coneFraction2;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline float NeutralClusterContact::GetConeFraction3() const
+{
+    return m_coneFraction3;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline pandora::Algorithm *NeutralFragmentRemovalAlgorithm::Factory::CreateAlgorithm() const
+{
+    return new NeutralFragmentRemovalAlgorithm();
+}
+
+} // namespace lc_content
+
+#endif // #ifndef LC_NEUTRAL_FRAGMENT_REMOVAL_ALGORITHM_H

--- a/include/LCContentFast/NeutralFragmentRemovalAlgorithmFast.h
+++ b/include/LCContentFast/NeutralFragmentRemovalAlgorithmFast.h
@@ -215,6 +215,6 @@ inline pandora::Algorithm *NeutralFragmentRemovalAlgorithm::Factory::CreateAlgor
     return new NeutralFragmentRemovalAlgorithm();
 }
 
-} // namespace lc_content
+} // namespace lc_content_fast
 
-#endif // #ifndef LC_NEUTRAL_FRAGMENT_REMOVAL_ALGORITHM_H
+#endif // #ifndef LC_NEUTRAL_FRAGMENT_REMOVAL_ALGORITHM_FAST_H

--- a/include/LCContentFast/PhotonFragmentRemovalAlgorithmFast.h
+++ b/include/LCContentFast/PhotonFragmentRemovalAlgorithmFast.h
@@ -1,0 +1,147 @@
+/**
+ *  @file   LCContent/include/LCContentFast/PhotonFragmentRemovalAlgorithmFast.h
+ * 
+ *  @brief  Header file for the photon fragment removal algorithm class.
+ * 
+ *  $Log: $
+ */
+#ifndef LC_PHOTON_FRAGMENT_REMOVAL_ALGORITHM_FAST_H
+#define LC_PHOTON_FRAGMENT_REMOVAL_ALGORITHM_FAST_H 1
+
+#include "Pandora/Algorithm.h"
+
+#include "LCContentFast/FragmentRemovalHelperFast.h"
+
+namespace lc_content_fast
+{
+
+/**
+ *  @brief  PhotonFragmentRemovalAlgorithm class
+ */
+class PhotonFragmentRemovalAlgorithm : public pandora::Algorithm
+{
+public:
+    /**
+     *  @brief  Factory class for instantiating algorithm
+     */
+    class Factory : public pandora::AlgorithmFactory
+    {
+    public:
+        pandora::Algorithm *CreateAlgorithm() const;
+    };
+
+    /**
+     *  @brief Default constructor
+     */
+    PhotonFragmentRemovalAlgorithm();
+
+private:
+    pandora::StatusCode Run();
+    pandora::StatusCode ReadSettings(const pandora::TiXmlHandle xmlHandle);
+
+    /**
+     *  @brief  Get cluster contact map, linking each daughter candidate cluster to a list of parent candidates and describing
+     *          the proximity/contact between each pairing
+     * 
+     *  @param  isFirstPass whether this is the first call to GetClusterContactMap
+     *  @param  affectedClusters list of those clusters affected by previous cluster merging, for which contact details must be updated
+     *  @param  clusterContactMap to receive the populated cluster contact map
+     */
+    pandora::StatusCode GetClusterContactMap(bool &isFirstPass, const pandora::ClusterList &affectedClusters, ClusterContactMap &clusterContactMap) const;
+
+    /**
+     *  @brief  Whether candidate daughter cluster can be considered as photon-like
+     * 
+     *  @param  pDaughterCluster address of the candidate daughter cluster
+     * 
+     *  @return boolean
+     */
+    bool IsPhotonLike(const pandora::Cluster *const pDaughterCluster) const;
+
+    /**
+     *  @brief  Whether candidate parent and daughter clusters are sufficiently in contact to warrant further investigation
+     * 
+     *  @param  clusterContact the cluster contact
+     * 
+     *  @return boolean
+     */
+    bool PassesClusterContactCuts(const ClusterContact &clusterContact) const;
+
+    /**
+     *  @brief  Find the best candidate parent and daughter clusters for fragment removal merging
+     * 
+     *  @param  clusterContactMap the populated cluster contact map
+     *  @param  pBestParentCluster to receive the address of the best parent cluster candidate
+     *  @param  pBestDaughterCluster to receive the address of the best daughter cluster candidate
+     */
+    pandora::StatusCode GetClusterMergingCandidates(const ClusterContactMap &clusterContactMap, const pandora::Cluster *&pBestParentCluster,
+        const pandora::Cluster *&pBestDaughterCluster) const;
+
+    /**
+     *  @brief  Get a measure of the evidence for merging the parent and daughter candidate clusters
+     * 
+     *  @param  clusterContact the cluster contact details for parent/daughter candidate merge
+     * 
+     *  @return the evidence
+     */
+    float GetEvidenceForMerge(const ClusterContact &clusterContact) const;
+
+    /**
+     *  @brief  Get the list of clusters for which cluster contact information will be affected by a specified cluster merge
+     * 
+     *  @param  clusterContactMap the cluster contact map
+     *  @param  pBestParentCluster address of the parent cluster to be merged
+     *  @param  pBestDaughterCluster address of the daughter cluster to be merged
+     *  @param  affectedClusters to receive the list of affected clusters
+     */
+    pandora::StatusCode GetAffectedClusters(const ClusterContactMap &clusterContactMap, const pandora::Cluster *const pBestParentCluster,
+        const pandora::Cluster *const pBestDaughterCluster, pandora::ClusterList &affectedClusters) const;
+
+    typedef ClusterContact::Parameters ContactParameters;
+    ContactParameters   m_contactParameters;                        ///< The cluster contact parameters
+
+    unsigned int        m_nMaxPasses;                               ///< Maximum number of passes over cluster contact information
+
+    unsigned int        m_minDaughterCaloHits;                      ///< Min number of calo hits in daughter candidate clusters
+    float               m_minDaughterHadronicEnergy;                ///< Min hadronic energy for daughter candidate clusters
+    unsigned int        m_innerLayerTolerance;                      ///< Max number of layers by which daughter can exceed parent inner layer
+    float               m_minCosOpeningAngle;                       ///< Min cos opening angle between candidate cluster initial directions
+
+    bool                m_useOnlyPhotonLikeDaughters;               ///< Whether to skip photon-like checks for daughter cluster
+
+    unsigned int        m_photonLikeMaxInnerLayer;                  ///< Max inner layer to identify daughter cluster as photon-like
+    float               m_photonLikeMinDCosR;                       ///< Max radial direction cosine to identify daughter as photon-like
+    float               m_photonLikeMaxShowerStart;                 ///< Max shower profile start to identify daughter as photon-like
+    float               m_photonLikeMaxProfileDiscrepancy;          ///< Max shower profile discrepancy to identify daughter as photon-like
+
+    float               m_contactCutMaxDistance;                    ///< Max distance between closest hits to store cluster contact info
+    unsigned int        m_contactCutNLayers;                        ///< Number of contact layers to store cluster contact info
+    float               m_contactCutConeFraction1;                  ///< Cone fraction 1 value to store cluster contact info
+    float               m_contactCutCloseHitFraction1;              ///< Close hit fraction 1 value to store cluster contact info
+    float               m_contactCutCloseHitFraction2;              ///< Close hit fraction 2 value to store cluster contact info
+
+    unsigned int        m_contactEvidenceNLayers;                   ///< Contact layers required for contact evidence contribution
+    float               m_contactEvidenceFraction;                  ///< Contact fraction required for contact evidence contribution
+    float               m_coneEvidenceFraction1;                    ///< Cone fraction 1 value required for cone evidence contribution
+    float               m_distanceEvidence1;                        ///< Offset for distance evidence contribution 1
+    float               m_distanceEvidence1d;                       ///< Denominator for distance evidence contribution 1
+    float               m_distanceEvidenceCloseFraction1Multiplier; ///< Distance evidence multiplier for close hit fraction 1
+    float               m_distanceEvidenceCloseFraction2Multiplier; ///< Distance evidence multiplier for close hit fraction 2
+
+    float               m_contactWeight;                            ///< Weight for layers in contact evidence
+    float               m_coneWeight;                               ///< Weight for cone extrapolation evidence
+    float               m_distanceWeight;                           ///< Weight for distance of closest approach evidence
+
+    float               m_minEvidence;                              ///< Min evidence before parent/daughter candidates can be merged
+};
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+inline pandora::Algorithm *PhotonFragmentRemovalAlgorithm::Factory::CreateAlgorithm() const
+{
+    return new PhotonFragmentRemovalAlgorithm();
+}
+
+} // namespace lc_content_fast
+
+#endif // #ifndef LC_PHOTON_FRAGMENT_REMOVAL_ALGORITHM_FAST_H

--- a/include/LCHelpers/SortingHelper.h
+++ b/include/LCHelpers/SortingHelper.h
@@ -11,6 +11,8 @@
 #include "Pandora/PandoraInputTypes.h"
 #include "Pandora/PandoraInternal.h"
 
+#include <utility>
+
 namespace lc_content
 {
 
@@ -75,6 +77,15 @@ public:
      *  @param  pRhs address of second track
      */
     static bool SortTracksByEnergy(const pandora::Track *const pLhs, const pandora::Track *const pRhs);
+	
+	/**
+     *  @brief  Sort CaloHits by distance to cluster centroid
+     * 
+     *  @param  pLhs address of first hit & distance
+     *  @param  pRhs address of second hit & distance
+     */
+    static bool SortHitsByRadiusToCentroid(const std::pair<const pandora::CaloHit *, float>& pLhs, const std::pair<const pandora::CaloHit *, float>& pRhs);
+	
 };
 
 } // namespace lc_content

--- a/src/LCContentFast/ConeClusteringAlgorithmFast.cc
+++ b/src/LCContentFast/ConeClusteringAlgorithmFast.cc
@@ -452,7 +452,7 @@ StatusCode ConeClusteringAlgorithm::FindHitsInSameLayer(unsigned int pseudoLayer
                         if( assc_cluster != m_hitsToClusters.end() )
                         {
                             auto nearby_iter = nearby_clusters.find(assc_cluster->second);
-							if(nearby_iter == nearby_clusters.end()){
+							if(nearby_iter == nearby_clusters.end() || nearby_iter->second == nullptr){
 								//assign the current hit as the nearest hit
 								nearby_clusters.emplace(assc_cluster->second,itr->second);
 							}

--- a/src/LCContentFast/ConeClusteringAlgorithmFast.cc
+++ b/src/LCContentFast/ConeClusteringAlgorithmFast.cc
@@ -480,7 +480,7 @@ StatusCode ConeClusteringAlgorithm::FindHitsInSameLayer(unsigned int pseudoLayer
                         if (assc_cluster != m_hitsToClusters.end())
                         {
                             auto nearby_iter = nearby_clusters.find(assc_cluster->second);
-							if(nearby_iter == nearby_clusters.end()){
+							if(nearby_iter == nearby_clusters.end() || nearby_iter->second == nullptr){
 								//assign the current hit as the nearest hit
 								nearby_clusters.emplace(assc_cluster->second,hit.data);
 							}

--- a/src/LCContentFast/ConeClusteringAlgorithmFast.cc
+++ b/src/LCContentFast/ConeClusteringAlgorithmFast.cc
@@ -316,7 +316,7 @@ StatusCode ConeClusteringAlgorithm::FindHitsInPreviousLayers(unsigned int pseudo
                 const float clusterEnergy(pCluster->GetHadronicEnergy());
 
                 PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_UNCHANGED, !=, this->GetGenericDistanceToHit(pCluster,
-                    pCaloHit, searchLayer, clusterFitResultMap, genericDistance));
+                    pCaloHit, searchLayer, clusterFitResultMap, genericDistance, nullptr));
 
                 if ((genericDistance < smallestGenericDistance) ||
                     ((genericDistance == smallestGenericDistance) && (clusterEnergy > bestClusterEnergy)))
@@ -377,7 +377,7 @@ StatusCode ConeClusteringAlgorithm::FindHitsInSameLayer(unsigned int pseudoLayer
     //pull out result caches to help keep memory locality
     std::vector<TrackKDNode> found_tracks;
     std::vector<HitKDNode> found_hits;
-    ClusterList nearby_clusters;
+    ClusterListWithNearestHit nearby_clusters;
 
     while (!available_hits_in_layer.empty())
     {
@@ -413,7 +413,11 @@ StatusCode ConeClusteringAlgorithm::FindHitsInSameLayer(unsigned int pseudoLayer
                         auto assc_cluster = m_tracksToClusters.find(itr->second);
                         if(assc_cluster != m_tracksToClusters.end())
                         {
-                            nearby_clusters.insert(assc_cluster->second);
+                            auto nearby_iter = nearby_clusters.find(assc_cluster->second);
+							if(nearby_iter == nearby_clusters.end()){
+								//no nearest hit from track search
+								nearby_clusters.emplace(assc_cluster->second,nullptr);
+							}
                         }
                     }
                 }
@@ -427,11 +431,16 @@ StatusCode ConeClusteringAlgorithm::FindHitsInSameLayer(unsigned int pseudoLayer
                         auto assc_cluster = m_tracksToClusters.find(track.data);
                         if (assc_cluster != m_tracksToClusters.end())
                         {
-                            nearby_clusters.insert(assc_cluster->second);
+                            auto nearby_iter = nearby_clusters.find(assc_cluster->second);
+							if(nearby_iter == nearby_clusters.end()){
+								//no nearest hit from track search
+								nearby_clusters.emplace(assc_cluster->second,nullptr);
+							}
                         }
                     }
                     found_tracks.clear();
                 }
+				
                 // now search for hits-in-clusters that would also satisfy the criteria
                 auto hits_assc_cache = hitsToHitsLocal.find(pCaloHit);
                 if (hits_assc_cache != hitsToHitsLocal.end())
@@ -442,7 +451,21 @@ StatusCode ConeClusteringAlgorithm::FindHitsInSameLayer(unsigned int pseudoLayer
                         auto assc_cluster = m_hitsToClusters.find(itr->second);
                         if( assc_cluster != m_hitsToClusters.end() )
                         {
-                            nearby_clusters.insert(assc_cluster->second);
+                            auto nearby_iter = nearby_clusters.find(assc_cluster->second);
+							if(nearby_iter == nearby_clusters.end()){
+								//assign the current hit as the nearest hit
+								nearby_clusters.emplace(assc_cluster->second,itr->second);
+							}
+							else {
+								//check if the current hit is nearer
+								//should the min distance be cached with the nearest hit?
+								const CartesianVector &hitPosition(pCaloHit->GetPositionVector());
+								const CartesianVector &nearPosition(nearby_iter->second->GetPositionVector());
+								const CartesianVector &testPosition(itr->second->GetPositionVector());
+								if((hitPosition-testPosition).GetMagnitudeSquared() < (hitPosition-nearPosition).GetMagnitudeSquared()){
+									nearby_iter->second = itr->second;
+								}
+							}
                         }
                     }
                 }
@@ -456,22 +479,36 @@ StatusCode ConeClusteringAlgorithm::FindHitsInSameLayer(unsigned int pseudoLayer
                         auto assc_cluster = m_hitsToClusters.find(hit.data);
                         if (assc_cluster != m_hitsToClusters.end())
                         {
-                            nearby_clusters.insert(assc_cluster->second);
+                            auto nearby_iter = nearby_clusters.find(assc_cluster->second);
+							if(nearby_iter == nearby_clusters.end()){
+								//assign the current hit as the nearest hit
+								nearby_clusters.emplace(assc_cluster->second,hit.data);
+							}
+							else {
+								//check if the current hit is nearer
+								//should the min distance be cached with the nearest hit?
+								const CartesianVector &hitPosition(pCaloHit->GetPositionVector());
+								const CartesianVector &nearPosition(nearby_iter->second->GetPositionVector());
+								const CartesianVector &testPosition(hit.data->GetPositionVector());
+								if((hitPosition-testPosition).GetMagnitudeSquared() < (hitPosition-nearPosition).GetMagnitudeSquared()){
+									nearby_iter->second = hit.data;
+								}
+							}
                         }
                     }
                     found_hits.clear();
                 }
 
                 // See if hit should be associated with any existing clusters
-                for (ClusterList::iterator clusterIter = nearby_clusters.begin(), clusterIterEnd = nearby_clusters.end();
+                for (auto clusterIter = nearby_clusters.begin(), clusterIterEnd = nearby_clusters.end();
                     clusterIter != clusterIterEnd; ++clusterIter)
                 {
-                    const Cluster *const pCluster = *clusterIter;
+                    const Cluster *const pCluster = clusterIter->first;
                     float genericDistance(std::numeric_limits<float>::max());
                     const float clusterEnergy(pCluster->GetHadronicEnergy());
 
                     PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_UNCHANGED, !=, this->GetGenericDistanceToHit(pCluster,
-                        pCaloHit, pseudoLayer, clusterFitResultMap, genericDistance));
+                        pCaloHit, pseudoLayer, clusterFitResultMap, genericDistance, clusterIter->second));
 
                     if ((genericDistance < smallestGenericDistance) || ((genericDistance == smallestGenericDistance) && (clusterEnergy > bestClusterEnergy)))
                     {
@@ -519,7 +556,7 @@ StatusCode ConeClusteringAlgorithm::FindHitsInSameLayer(unsigned int pseudoLayer
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode ConeClusteringAlgorithm::GetGenericDistanceToHit(const Cluster *const pCluster, const CaloHit *const pCaloHit, const unsigned int searchLayer,
-    const ClusterFitResultMap &clusterFitResultMap, float &genericDistance) const
+    const ClusterFitResultMap &clusterFitResultMap, float &genericDistance, const CaloHit *const nearestHit) const
 {
     const unsigned int firstLayer = m_firstLayer;
 
@@ -563,7 +600,7 @@ StatusCode ConeClusteringAlgorithm::GetGenericDistanceToHit(const Cluster *const
 
         if (searchLayer == pCaloHit->GetPseudoLayer())
         {
-            return this->GetDistanceToHitInSameLayer(pCaloHit, pClusterCaloHitList, genericDistance);
+            return this->GetDistanceToHitInSameLayer(pCaloHit, pClusterCaloHitList, genericDistance, nearestHit);
         }
 
         // Measurement using initial cluster direction
@@ -637,7 +674,7 @@ StatusCode ConeClusteringAlgorithm::GetGenericDistanceToHit(const Cluster *const
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 StatusCode ConeClusteringAlgorithm::GetDistanceToHitInSameLayer(const CaloHit *const pCaloHit, const CaloHitList *const pCaloHitList,
-    float &distance) const
+    float &distance, const CaloHit *const nearestHit) const
 {
     const float dCut ((PandoraContentApi::GetGeometry(*this)->GetHitTypeGranularity(pCaloHit->GetHitType()) <= FINE) ?
         (m_sameLayerPadWidthsFine * pCaloHit->GetCellLengthScale()) :
@@ -651,11 +688,9 @@ StatusCode ConeClusteringAlgorithm::GetDistanceToHitInSameLayer(const CaloHit *c
     bool hitFound(false);
     float smallestDistanceSquared(std::numeric_limits<float>::max());
     const float rDCutSquared(1.f / (dCut * dCut));
-
-    for (CaloHitList::const_iterator iter = pCaloHitList->begin(), iterEnd = pCaloHitList->end(); iter != iterEnd; ++iter)
-    {
-        const CaloHit *const pHitInCluster = *iter;
-        const CartesianVector &hitInClusterPosition(pHitInCluster->GetPositionVector());
+	
+	if(nearestHit != nullptr){ //no need to loop if the nearest hit is already known
+        const CartesianVector &hitInClusterPosition(nearestHit->GetPositionVector());
         const float separationSquared((hitPosition - hitInClusterPosition).GetMagnitudeSquared());
         const float hitDistanceSquared(separationSquared * rDCutSquared);
 
@@ -663,8 +698,23 @@ StatusCode ConeClusteringAlgorithm::GetDistanceToHitInSameLayer(const CaloHit *c
         {
             smallestDistanceSquared = hitDistanceSquared;
             hitFound = true;
+        }		
+	}
+	else{
+        for (CaloHitList::const_iterator iter = pCaloHitList->begin(), iterEnd = pCaloHitList->end(); iter != iterEnd; ++iter)
+        {
+            const CaloHit *const pHitInCluster = *iter;
+            const CartesianVector &hitInClusterPosition(pHitInCluster->GetPositionVector());
+            const float separationSquared((hitPosition - hitInClusterPosition).GetMagnitudeSquared());
+            const float hitDistanceSquared(separationSquared * rDCutSquared);
+        
+            if (hitDistanceSquared < smallestDistanceSquared)
+            {
+                smallestDistanceSquared = hitDistanceSquared;
+                hitFound = true;
+            }
         }
-    }
+	}
 
     if (!hitFound)
         return STATUS_CODE_UNCHANGED;

--- a/src/LCContentFast/FragmentRemovalHelperFast.cc
+++ b/src/LCContentFast/FragmentRemovalHelperFast.cc
@@ -9,6 +9,10 @@
 #include "Pandora/AlgorithmHeaders.h"
 
 #include "LCContentFast/FragmentRemovalHelperFast.h"
+#include "LCHelpers/SortingHelper.h"
+
+#include <utility>
+#include <algorithm>
 
 using namespace pandora;
 
@@ -365,31 +369,51 @@ void ClusterContact::HitDistanceComparison(const Cluster *const pDaughterCluster
     const OrderedCaloHitList &orderedCaloHitListI(pDaughterCluster->GetOrderedCaloHitList());
     const OrderedCaloHitList &orderedCaloHitListJ(pParentCluster->GetOrderedCaloHitList());
 
+	//fill vector of parent hits
+	const unsigned int nParentCaloHits(pParentCluster->GetNCaloHits());
+	std::vector<std::pair<const CaloHit*, float> > parentRadii;
+	parentRadii.reserve(nParentCaloHits);
+	const unsigned int nClosestHits = 6; //todo: make configurable
+	const unsigned int nActualClosestHits = std::min(nClosestHits,nParentCaloHits);
+	for (OrderedCaloHitList::const_iterator iterJ = orderedCaloHitListJ.begin(), iterJEnd = orderedCaloHitListJ.end(); iterJ != iterJEnd; ++iterJ)
+	{
+		for (CaloHitList::const_iterator hitIterJ = iterJ->second->begin(), hitIterJEnd = iterJ->second->end(); hitIterJ != hitIterJEnd; ++hitIterJ)
+		{
+			parentRadii.emplace_back(*hitIterJ, 0.f);
+		}
+	}
+	
     // Loop over hits in daughter cluster
     for (OrderedCaloHitList::const_iterator iterI = orderedCaloHitListI.begin(), iterIEnd = orderedCaloHitListI.end(); iterI != iterIEnd; ++iterI)
     {
+		const CartesianVector centroidVector(pDaughterCluster->GetCentroid(iterI->first));
+
+		//sort parent hits by radial distance to centroid
+		for(unsigned int indexJ = 0; indexJ < parentRadii.size(); ++indexJ){
+			parentRadii.at(indexJ).second = (centroidVector - parentRadii.at(indexJ).first->GetPositionVector()).GetMagnitudeSquared();
+		}
+		
+		//find m closest parent hits
+		std::partial_sort(parentRadii.begin(),parentRadii.begin()+nActualClosestHits,parentRadii.end(),lc_content::SortingHelper::SortHitsByRadiusToCentroid);
+		
         for (CaloHitList::const_iterator hitIterI = iterI->second->begin(), hitIterIEnd = iterI->second->end(); hitIterI != hitIterIEnd; ++hitIterI)
         {
             bool isCloseHit1(false), isCloseHit2(false);
             const CartesianVector &positionVectorI((*hitIterI)->GetPositionVector());
 
-            // Compare each hit in daughter cluster with those in parent cluster
-            for (OrderedCaloHitList::const_iterator iterJ = orderedCaloHitListJ.begin(), iterJEnd = orderedCaloHitListJ.end(); iterJ != iterJEnd; ++iterJ)
-            {
-                for (CaloHitList::const_iterator hitIterJ = iterJ->second->begin(), hitIterJEnd = iterJ->second->end(); hitIterJ != hitIterJEnd; ++hitIterJ)
-                {
-                    const float distanceSquared((positionVectorI - (*hitIterJ)->GetPositionVector()).GetMagnitudeSquared());
+			//compare only closest parent hits to daughter hits
+			for(unsigned int indexJ = 0; indexJ < nActualClosestHits; ++indexJ){
+				const float distanceSquared((positionVectorI - (parentRadii.at(indexJ).first)->GetPositionVector()).GetMagnitudeSquared());
 
-                    if (!isCloseHit1 && (distanceSquared < closeHitDistance1Squared))
-                        isCloseHit1 = true;
+				if (!isCloseHit1 && (distanceSquared < closeHitDistance1Squared))
+					isCloseHit1 = true;
 
-                    if (!isCloseHit2 && (distanceSquared < closeHitDistance2Squared))
-                        isCloseHit2 = true;
+				if (!isCloseHit2 && (distanceSquared < closeHitDistance2Squared))
+					isCloseHit2 = true;
 
-                    if (distanceSquared < minDistanceSquared)
-                        minDistanceSquared = distanceSquared;
-                }
-            }
+				if (distanceSquared < minDistanceSquared)
+					minDistanceSquared = distanceSquared;
+			}
 
             if (isCloseHit1)
                 nCloseHits1++;

--- a/src/LCContentFast/FragmentRemovalHelperFast.cc
+++ b/src/LCContentFast/FragmentRemovalHelperFast.cc
@@ -373,7 +373,7 @@ void ClusterContact::HitDistanceComparison(const Cluster *const pDaughterCluster
 	const unsigned int nParentCaloHits(pParentCluster->GetNCaloHits());
 	std::vector<std::pair<const CaloHit*, float> > parentRadii;
 	parentRadii.reserve(nParentCaloHits);
-	const unsigned int nClosestHits = 6; //todo: make configurable
+	const unsigned int nClosestHits = 10; //todo: make configurable
 	const unsigned int nActualClosestHits = std::min(nClosestHits,nParentCaloHits);
 	for (OrderedCaloHitList::const_iterator iterJ = orderedCaloHitListJ.begin(), iterJEnd = orderedCaloHitListJ.end(); iterJ != iterJEnd; ++iterJ)
 	{

--- a/src/LCContentFast/FragmentRemovalHelperFast.cc
+++ b/src/LCContentFast/FragmentRemovalHelperFast.cc
@@ -133,7 +133,7 @@ float FragmentRemovalHelper::GetFractionOfHitsInCone(const Cluster *const pClust
         {
             const CartesianVector &hitPosition((*hitIter)->GetPositionVector());
             const CartesianVector positionDifference(hitPosition - coneApex);
-			const float magnitude(positionDifference->GetMagnitude());
+			const float magnitude(positionDifference.GetMagnitude());
 			
 			if (std::fabs(magnitude) < std::numeric_limits<float>::epsilon()){
 				if (hitPosition == coneApex)

--- a/src/LCContentFast/FragmentRemovalHelperFast.cc
+++ b/src/LCContentFast/FragmentRemovalHelperFast.cc
@@ -133,17 +133,16 @@ float FragmentRemovalHelper::GetFractionOfHitsInCone(const Cluster *const pClust
         {
             const CartesianVector &hitPosition((*hitIter)->GetPositionVector());
             const CartesianVector positionDifference(hitPosition - coneApex);
-
-            try
-            {
-                const float cosTheta(coneDirection.GetDotProduct(positionDifference.GetUnitVector()));
+			const float magnitude(positionDifference->GetMagnitude());
+			
+			if (std::fabs(magnitude) < std::numeric_limits<float>::epsilon()){
+				if (hitPosition == coneApex)
+                    nHitsInCone++;
+			}
+			else {
+                const float cosTheta((coneDirection.GetDotProduct(positionDifference))/magnitude);
 
                 if (cosTheta > coneCosineHalfAngle)
-                    nHitsInCone++;
-            }
-            catch (StatusCodeException &)
-            {
-                if (hitPosition == coneApex)
                     nHitsInCone++;
             }
         }

--- a/src/LCContentFast/FragmentRemovalHelperFast.cc
+++ b/src/LCContentFast/FragmentRemovalHelperFast.cc
@@ -373,7 +373,7 @@ void ClusterContact::HitDistanceComparison(const Cluster *const pDaughterCluster
 	const unsigned int nParentCaloHits(pParentCluster->GetNCaloHits());
 	std::vector<std::pair<const CaloHit*, float> > parentRadii;
 	parentRadii.reserve(nParentCaloHits);
-	const unsigned int nClosestHits = 10; //todo: make configurable
+	const unsigned int nClosestHits = 6; //todo: make configurable
 	const unsigned int nActualClosestHits = std::min(nClosestHits,nParentCaloHits);
 	for (OrderedCaloHitList::const_iterator iterJ = orderedCaloHitListJ.begin(), iterJEnd = orderedCaloHitListJ.end(); iterJ != iterJEnd; ++iterJ)
 	{
@@ -388,13 +388,15 @@ void ClusterContact::HitDistanceComparison(const Cluster *const pDaughterCluster
     {
 		const CartesianVector centroidVector(pDaughterCluster->GetCentroid(iterI->first));
 
-		//sort parent hits by radial distance to centroid
-		for(unsigned int indexJ = 0; indexJ < parentRadii.size(); ++indexJ){
-			parentRadii.at(indexJ).second = (centroidVector - parentRadii.at(indexJ).first->GetPositionVector()).GetMagnitudeSquared();
+		if(nActualClosestHits < parentRadii.size()){ //partial_sort is only useful if it considers less than the total number of parent hits
+			//sort parent hits by radial distance to centroid
+			for(unsigned int indexJ = 0; indexJ < parentRadii.size(); ++indexJ){
+				parentRadii.at(indexJ).second = (centroidVector - parentRadii.at(indexJ).first->GetPositionVector()).GetMagnitudeSquared();
+			}
+			
+			//find m closest parent hits
+			std::partial_sort(parentRadii.begin(),parentRadii.begin()+nActualClosestHits,parentRadii.end(),lc_content::SortingHelper::SortHitsByRadiusToCentroid);
 		}
-		
-		//find m closest parent hits
-		std::partial_sort(parentRadii.begin(),parentRadii.begin()+nActualClosestHits,parentRadii.end(),lc_content::SortingHelper::SortHitsByRadiusToCentroid);
 		
         for (CaloHitList::const_iterator hitIterI = iterI->second->begin(), hitIterIEnd = iterI->second->end(); hitIterI != hitIterIEnd; ++hitIterI)
         {

--- a/src/LCContentFast/NeutralFragmentRemovalAlgorithmFast.cc
+++ b/src/LCContentFast/NeutralFragmentRemovalAlgorithmFast.cc
@@ -443,4 +443,4 @@ StatusCode NeutralFragmentRemovalAlgorithm::ReadSettings(const TiXmlHandle xmlHa
     return STATUS_CODE_SUCCESS;
 }
 
-} // namespace lc_content
+} // namespace lc_content_fast

--- a/src/LCContentFast/NeutralFragmentRemovalAlgorithmFast.cc
+++ b/src/LCContentFast/NeutralFragmentRemovalAlgorithmFast.cc
@@ -1,0 +1,446 @@
+/**
+ *  @file   LCContent/src/LCContentFast/NeutralFragmentRemovalAlgorithmFast.cc
+ * 
+ *  @brief  Implementation of the neutral fragment removal algorithm class.
+ * 
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include "LCContentFast/NeutralFragmentRemovalAlgorithmFast.h"
+
+using namespace pandora;
+
+namespace lc_content_fast
+{
+
+NeutralFragmentRemovalAlgorithm::NeutralFragmentRemovalAlgorithm() :
+    m_nMaxPasses(200),
+    m_minDaughterCaloHits(5),
+    m_minDaughterHadronicEnergy(0.025f),
+    m_photonLikeMaxInnerLayer(10),
+    m_photonLikeMinDCosR(0.5f),
+    m_photonLikeMaxShowerStart(5.f),
+    m_photonLikeMaxProfileDiscrepancy(0.75f),
+    m_contactCutMaxDistance(500.f),
+    m_contactCutNLayers(2),
+    m_contactCutConeFraction1(0.5f),
+    m_contactCutCloseHitFraction1(0.5f),
+    m_contactCutCloseHitFraction2(0.5f),
+    m_contactCutNearbyDistance(100.f),
+    m_contactCutNearbyCloseHitFraction2(0.25f),
+    m_contactEvidenceNLayers1(10),
+    m_contactEvidenceNLayers2(4),
+    m_contactEvidenceNLayers3(1),
+    m_contactEvidence1(2.f),
+    m_contactEvidence2(1.f),
+    m_contactEvidence3(0.5f),
+    m_coneEvidenceFraction1(0.5f),
+    m_coneEvidenceFineGranularityMultiplier(0.5f),
+    m_distanceEvidence1(100.f),
+    m_distanceEvidence1d(100.f),
+    m_distanceEvidenceCloseFraction1Multiplier(1.f),
+    m_distanceEvidenceCloseFraction2Multiplier(2.f),
+    m_contactWeight(1.f),
+    m_coneWeight(1.f),
+    m_distanceWeight(1.f),
+    m_minEvidence(2.f)
+{
+    m_contactParameters.m_coneCosineHalfAngle1 = 0.9f;
+    m_contactParameters.m_coneCosineHalfAngle2 = 0.95f;
+    m_contactParameters.m_coneCosineHalfAngle3 = 0.985f;
+    m_contactParameters.m_closeHitDistance1 = 100.f;
+    m_contactParameters.m_closeHitDistance2 = 50.f;
+    m_contactParameters.m_minCosOpeningAngle = 0.5f;
+    m_contactParameters.m_distanceThreshold = 2.f;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode NeutralFragmentRemovalAlgorithm::Run()
+{
+    unsigned int nPasses(0);
+    bool isFirstPass(true), shouldRecalculate(true);
+
+    ClusterList affectedClusters;
+    NeutralClusterContactMap neutralClusterContactMap;
+
+    while ((nPasses++ < m_nMaxPasses) && shouldRecalculate)
+    {
+        shouldRecalculate = false;
+        const Cluster *pBestParentCluster(NULL), *pBestDaughterCluster(NULL);
+
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->GetNeutralClusterContactMap(isFirstPass, affectedClusters, neutralClusterContactMap));
+
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->GetClusterMergingCandidates(neutralClusterContactMap, pBestParentCluster,
+            pBestDaughterCluster));
+
+        if ((NULL != pBestParentCluster) && (NULL != pBestDaughterCluster))
+        {
+            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->GetAffectedClusters(neutralClusterContactMap, pBestParentCluster,
+                pBestDaughterCluster, affectedClusters));
+
+            neutralClusterContactMap.erase(neutralClusterContactMap.find(pBestDaughterCluster));
+            shouldRecalculate = true;
+
+            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::MergeAndDeleteClusters(*this, pBestParentCluster,
+                pBestDaughterCluster));
+        }
+    }
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode NeutralFragmentRemovalAlgorithm::GetNeutralClusterContactMap(bool &isFirstPass, const ClusterList &affectedClusters,
+    NeutralClusterContactMap &neutralClusterContactMap) const
+{
+    const ClusterList *pClusterList = NULL;
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pClusterList));
+
+    for (ClusterList::const_iterator iterI = pClusterList->begin(), iterIEnd = pClusterList->end(); iterI != iterIEnd; ++iterI)
+    {
+        const Cluster *const pDaughterCluster = *iterI;
+
+        // Identify whether cluster contacts need to be recalculated
+        if (!isFirstPass)
+        {
+            if (affectedClusters.end() == affectedClusters.find(pDaughterCluster))
+                continue;
+
+            NeutralClusterContactMap::iterator pastEntryIter = neutralClusterContactMap.find(pDaughterCluster);
+
+            if (neutralClusterContactMap.end() != pastEntryIter)
+                neutralClusterContactMap.erase(neutralClusterContactMap.find(pDaughterCluster));
+        }
+
+        // Apply simple daughter selection cuts
+        if (!pDaughterCluster->GetAssociatedTrackList().empty() || this->IsPhotonLike(pDaughterCluster))
+            continue;
+
+        if ((pDaughterCluster->GetNCaloHits() < m_minDaughterCaloHits) || (pDaughterCluster->GetHadronicEnergy() < m_minDaughterHadronicEnergy))
+            continue;
+
+        // Calculate the cluster contact information
+        for (ClusterList::const_iterator iterJ = pClusterList->begin(), iterJEnd = pClusterList->end(); iterJ != iterJEnd; ++iterJ)
+        {
+            const Cluster *const pParentCluster = *iterJ;
+
+            if (pDaughterCluster == pParentCluster)
+                continue;
+
+            if (!pParentCluster->GetAssociatedTrackList().empty() || pParentCluster->IsPhotonFast(this->GetPandora()))
+                continue;
+
+            const NeutralClusterContact neutralClusterContact(this->GetPandora(), pDaughterCluster, pParentCluster, m_contactParameters);
+
+            if (this->PassesClusterContactCuts(neutralClusterContact))
+            {
+                neutralClusterContactMap[pDaughterCluster].push_back(neutralClusterContact);
+            }
+        }
+    }
+    isFirstPass = false;
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool NeutralFragmentRemovalAlgorithm::IsPhotonLike(const Cluster *const pDaughterCluster) const
+{
+    if (pDaughterCluster->IsPhotonFast(this->GetPandora()))
+        return true;
+
+    const ClusterFitResult &clusterFitResult(pDaughterCluster->GetFitToAllHitsResult());
+
+    if ((PandoraContentApi::GetGeometry(*this)->GetHitTypeGranularity(pDaughterCluster->GetInnerLayerHitType()) <= FINE) &&
+        (pDaughterCluster->GetInnerPseudoLayer() < m_photonLikeMaxInnerLayer) &&
+        (clusterFitResult.IsFitSuccessful()) && (clusterFitResult.GetRadialDirectionCosine() > m_photonLikeMinDCosR) &&
+        (pDaughterCluster->GetShowerProfileStart(this->GetPandora()) < m_photonLikeMaxShowerStart) &&
+        (pDaughterCluster->GetShowerProfileDiscrepancy(this->GetPandora()) < m_photonLikeMaxProfileDiscrepancy))
+    {
+        return true;
+    }
+
+    return false;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool NeutralFragmentRemovalAlgorithm::PassesClusterContactCuts(const NeutralClusterContact &neutralClusterContact) const
+{
+    if (neutralClusterContact.GetDistanceToClosestHit() > m_contactCutMaxDistance)
+        return false;
+
+    if ((neutralClusterContact.GetNContactLayers() > m_contactCutNLayers) ||
+        (neutralClusterContact.GetConeFraction1() > m_contactCutConeFraction1) ||
+        (neutralClusterContact.GetCloseHitFraction1() > m_contactCutCloseHitFraction1) ||
+        (neutralClusterContact.GetCloseHitFraction2() > m_contactCutCloseHitFraction2))
+    {
+        return true;
+    }
+
+    return ((neutralClusterContact.GetDistanceToClosestHit() < m_contactCutNearbyDistance) &&
+        (neutralClusterContact.GetCloseHitFraction2() > m_contactCutNearbyCloseHitFraction2));
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode NeutralFragmentRemovalAlgorithm::GetClusterMergingCandidates(const NeutralClusterContactMap &neutralClusterContactMap, const Cluster *&pBestParentCluster,
+    const Cluster *&pBestDaughterCluster) const
+{
+    float highestEvidence(m_minEvidence);
+    float highestEvidenceParentEnergy(0.);
+
+    for (NeutralClusterContactMap::const_iterator iterI = neutralClusterContactMap.begin(), iterIEnd = neutralClusterContactMap.end(); iterI != iterIEnd; ++iterI)
+    {
+        const Cluster *const pDaughterCluster = iterI->first;
+
+        for (NeutralClusterContactVector::const_iterator iterJ = iterI->second.begin(), iterJEnd = iterI->second.end(); iterJ != iterJEnd; ++iterJ)
+        {
+            NeutralClusterContact neutralClusterContact = *iterJ;
+
+            if (pDaughterCluster != neutralClusterContact.GetDaughterCluster())
+                throw StatusCodeException(STATUS_CODE_FAILURE);
+
+            const float evidence(this->GetEvidenceForMerge(neutralClusterContact));
+
+            const float parentEnergy(neutralClusterContact.GetParentCluster()->GetHadronicEnergy());
+
+            if ((evidence > highestEvidence) || ((evidence == highestEvidence) && (parentEnergy > highestEvidenceParentEnergy)))
+            {
+                highestEvidence = evidence;
+                pBestDaughterCluster = pDaughterCluster;
+                pBestParentCluster = neutralClusterContact.GetParentCluster();
+                highestEvidenceParentEnergy = parentEnergy;
+            }
+        }
+    }
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+float NeutralFragmentRemovalAlgorithm::GetEvidenceForMerge(const NeutralClusterContact &neutralClusterContact) const
+{
+    // Calculate a measure of the evidence that the daughter candidate cluster is a fragment of the parent candidate cluster:
+
+    // 1. Layers in contact
+    float contactEvidence(0.f);
+    if (neutralClusterContact.GetNContactLayers() > m_contactEvidenceNLayers1)
+    {
+        contactEvidence = m_contactEvidence1;
+    }
+    else if (neutralClusterContact.GetNContactLayers() > m_contactEvidenceNLayers2)
+    {
+        contactEvidence = m_contactEvidence2;
+    }
+    else if (neutralClusterContact.GetNContactLayers() > m_contactEvidenceNLayers3)
+    {
+        contactEvidence = m_contactEvidence3;
+    }
+    contactEvidence *= (1.f + neutralClusterContact.GetContactFraction());
+
+    // 2. Cone extrapolation
+    float coneEvidence(0.f);
+    if (neutralClusterContact.GetConeFraction1() > m_coneEvidenceFraction1)
+    {
+        coneEvidence = neutralClusterContact.GetConeFraction1() + neutralClusterContact.GetConeFraction2() + neutralClusterContact.GetConeFraction3();
+
+        if (PandoraContentApi::GetGeometry(*this)->GetHitTypeGranularity(neutralClusterContact.GetDaughterCluster()->GetInnerLayerHitType()) <= FINE)
+            coneEvidence *= m_coneEvidenceFineGranularityMultiplier;
+    }
+
+    // 3. Distance of closest approach
+    float distanceEvidence(0.f);
+    if (neutralClusterContact.GetDistanceToClosestHit() < m_distanceEvidence1)
+    {
+        distanceEvidence = (m_distanceEvidence1 - neutralClusterContact.GetDistanceToClosestHit()) / m_distanceEvidence1d;
+        distanceEvidence += m_distanceEvidenceCloseFraction1Multiplier * neutralClusterContact.GetCloseHitFraction1();
+        distanceEvidence += m_distanceEvidenceCloseFraction2Multiplier * neutralClusterContact.GetCloseHitFraction2();
+    }
+
+    return ((m_contactWeight * contactEvidence) + (m_coneWeight * coneEvidence) + (m_distanceWeight * distanceEvidence));
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode NeutralFragmentRemovalAlgorithm::GetAffectedClusters(const NeutralClusterContactMap &neutralClusterContactMap, const Cluster *const pBestParentCluster,
+    const Cluster *const pBestDaughterCluster, ClusterList &affectedClusters) const
+{
+    if (neutralClusterContactMap.end() == neutralClusterContactMap.find(pBestDaughterCluster))
+        return STATUS_CODE_FAILURE;
+
+    affectedClusters.clear();
+    for (NeutralClusterContactMap::const_iterator iterI = neutralClusterContactMap.begin(), iterIEnd = neutralClusterContactMap.end(); iterI != iterIEnd; ++iterI)
+    {
+        // Store addresses of all clusters that were in contact with the newly deleted daughter cluster
+        if (iterI->first == pBestDaughterCluster)
+        {
+            for (NeutralClusterContactVector::const_iterator iterJ = iterI->second.begin(), iterJEnd = iterI->second.end(); iterJ != iterJEnd; ++iterJ)
+            {
+                affectedClusters.insert(iterJ->GetParentCluster());
+            }
+            continue;
+        }
+
+        // Also store addresses of all clusters that contained either the parent or daughter clusters in their own NeutralClusterContactVectors
+        for (NeutralClusterContactVector::const_iterator iterJ = iterI->second.begin(), iterJEnd = iterI->second.end(); iterJ != iterJEnd; ++iterJ)
+        {
+            if ((iterJ->GetParentCluster() == pBestParentCluster) || (iterJ->GetParentCluster() == pBestDaughterCluster))
+            {
+                affectedClusters.insert(iterI->first);
+                break;
+            }
+        }
+    }
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+NeutralClusterContact::NeutralClusterContact(const Pandora &pandora, const Cluster *const pDaughterCluster, const Cluster *const pParentCluster,
+        const Parameters &parameters) :
+    ClusterContact(pandora, pDaughterCluster, pParentCluster, parameters),
+    m_coneFraction2(FragmentRemovalHelper::GetFractionOfHitsInCone(pandora, pDaughterCluster, pParentCluster, parameters.m_coneCosineHalfAngle2)),
+    m_coneFraction3(FragmentRemovalHelper::GetFractionOfHitsInCone(pandora, pDaughterCluster, pParentCluster, parameters.m_coneCosineHalfAngle3))
+{
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode NeutralFragmentRemovalAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
+{
+    // Cluster contact parameters
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ConeCosineHalfAngle1", m_contactParameters.m_coneCosineHalfAngle1));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ConeCosineHalfAngle2", m_contactParameters.m_coneCosineHalfAngle2));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ConeCosineHalfAngle3", m_contactParameters.m_coneCosineHalfAngle3));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "CloseHitDistance1", m_contactParameters.m_closeHitDistance1));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "CloseHitDistance2", m_contactParameters.m_closeHitDistance2));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "MinCosOpeningAngle", m_contactParameters.m_minCosOpeningAngle));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "DistanceThreshold", m_contactParameters.m_distanceThreshold));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "NMaxPasses", m_nMaxPasses));
+
+    // Initial daughter cluster selection
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "MinDaughterCaloHits", m_minDaughterCaloHits));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "MinDaughterHadronicEnergy", m_minDaughterHadronicEnergy));
+
+    // Photon-like cuts
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "PhotonLikeMaxInnerLayer", m_photonLikeMaxInnerLayer));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "PhotonLikeMinDCosR", m_photonLikeMinDCosR));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "PhotonLikeMaxShowerStart", m_photonLikeMaxShowerStart));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "PhotonLikeMaxProfileDiscrepancy", m_photonLikeMaxProfileDiscrepancy));
+
+    // Cluster contact cuts
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ContactCutMaxDistance", m_contactCutMaxDistance));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ContactCutNLayers", m_contactCutNLayers));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ContactCutConeFraction1", m_contactCutConeFraction1));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ContactCutCloseHitFraction1", m_contactCutCloseHitFraction1));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ContactCutCloseHitFraction2", m_contactCutCloseHitFraction2));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ContactCutNearbyDistance", m_contactCutNearbyDistance));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ContactCutNearbyCloseHitFraction2", m_contactCutNearbyCloseHitFraction2));
+
+    // Total evidence: Contact evidence
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ContactEvidenceNLayers1", m_contactEvidenceNLayers1));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ContactEvidenceNLayers2", m_contactEvidenceNLayers2));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ContactEvidenceNLayers3", m_contactEvidenceNLayers3));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ContactEvidence1", m_contactEvidence1));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ContactEvidence2", m_contactEvidence2));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ContactEvidence3", m_contactEvidence3));
+
+    // Cone evidence
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ConeEvidenceFraction1", m_coneEvidenceFraction1));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ConeEvidenceFineGranularityMultiplier", m_coneEvidenceFineGranularityMultiplier));
+
+    // Distance of closest approach evidence
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "DistanceEvidence1", m_distanceEvidence1));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "DistanceEvidence1d", m_distanceEvidence1d));
+
+    if (m_distanceEvidence1d < std::numeric_limits<float>::epsilon())
+        return STATUS_CODE_INVALID_PARAMETER;
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "DistanceEvidenceCloseFraction1Multiplier", m_distanceEvidenceCloseFraction1Multiplier));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "DistanceEvidenceCloseFraction2Multiplier", m_distanceEvidenceCloseFraction2Multiplier));
+
+    // Evidence weightings
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ContactWeight", m_contactWeight));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ConeWeight", m_coneWeight));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "DistanceWeight", m_distanceWeight));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "MinEvidence", m_minEvidence));
+
+    return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lc_content

--- a/src/LCContentFast/PhotonFragmentRemovalAlgorithmFast.cc
+++ b/src/LCContentFast/PhotonFragmentRemovalAlgorithmFast.cc
@@ -1,0 +1,416 @@
+/**
+ *  @file   LCContent/src/LCContentFast/PhotonFragmentRemovalAlgorithmFast.cc
+ * 
+ *  @brief  Implementation of the photon fragment removal algorithm class.
+ * 
+ *  $Log: $
+ */
+
+#include "Pandora/AlgorithmHeaders.h"
+
+#include "LCContentFast/PhotonFragmentRemovalAlgorithmFast.h"
+
+using namespace pandora;
+
+namespace lc_content_fast
+{
+
+PhotonFragmentRemovalAlgorithm::PhotonFragmentRemovalAlgorithm() :
+    m_nMaxPasses(200),
+    m_minDaughterCaloHits(5),
+    m_minDaughterHadronicEnergy(0.025f),
+    m_innerLayerTolerance(5),
+    m_minCosOpeningAngle(0.95f),
+    m_useOnlyPhotonLikeDaughters(true),
+    m_photonLikeMaxInnerLayer(10),
+    m_photonLikeMinDCosR(0.5f),
+    m_photonLikeMaxShowerStart(5.f),
+    m_photonLikeMaxProfileDiscrepancy(0.75f),
+    m_contactCutMaxDistance(20.f),
+    m_contactCutNLayers(2),
+    m_contactCutConeFraction1(0.5f),
+    m_contactCutCloseHitFraction1(0.5f),
+    m_contactCutCloseHitFraction2(0.2f),
+    m_contactEvidenceNLayers(2),
+    m_contactEvidenceFraction(0.5f),
+    m_coneEvidenceFraction1(0.5f),
+    m_distanceEvidence1(100.f),
+    m_distanceEvidence1d(100.f),
+    m_distanceEvidenceCloseFraction1Multiplier(1.f),
+    m_distanceEvidenceCloseFraction2Multiplier(2.f),
+    m_contactWeight(1.f),
+    m_coneWeight(1.f),
+    m_distanceWeight(1.f),
+    m_minEvidence(2.f)
+{
+    m_contactParameters.m_coneCosineHalfAngle1 = 0.95f;
+    m_contactParameters.m_closeHitDistance1 = 40.f;
+    m_contactParameters.m_closeHitDistance2 = 20.f;
+    m_contactParameters.m_minCosOpeningAngle = 0.95f;
+    m_contactParameters.m_distanceThreshold = 2.f;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode PhotonFragmentRemovalAlgorithm::Run()
+{
+    unsigned int nPasses(0);
+    bool isFirstPass(true), shouldRecalculate(true);
+
+    ClusterList affectedClusters;
+    ClusterContactMap clusterContactMap;
+
+    while ((nPasses++ < m_nMaxPasses) && shouldRecalculate)
+    {
+        shouldRecalculate = false;
+        const Cluster *pBestParentCluster(NULL), *pBestDaughterCluster(NULL);
+
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->GetClusterContactMap(isFirstPass, affectedClusters, clusterContactMap));
+
+        PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->GetClusterMergingCandidates(clusterContactMap, pBestParentCluster,
+            pBestDaughterCluster));
+
+        if ((NULL != pBestParentCluster) && (NULL != pBestDaughterCluster))
+        {
+            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, this->GetAffectedClusters(clusterContactMap, pBestParentCluster,
+                pBestDaughterCluster, affectedClusters));
+
+            clusterContactMap.erase(clusterContactMap.find(pBestDaughterCluster));
+            shouldRecalculate = true;
+
+            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::MergeAndDeleteClusters(*this, pBestParentCluster,
+                pBestDaughterCluster));
+
+            PandoraContentApi::Cluster::Metadata metadata;
+            metadata.m_particleId = PHOTON;
+            PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::AlterMetadata(*this, pBestParentCluster, metadata));
+        }
+    }
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode PhotonFragmentRemovalAlgorithm::GetClusterContactMap(bool &isFirstPass, const ClusterList &affectedClusters,
+    ClusterContactMap &clusterContactMap) const
+{
+    const ClusterList *pClusterList = NULL;
+    PANDORA_RETURN_RESULT_IF(STATUS_CODE_SUCCESS, !=, PandoraContentApi::GetCurrentList(*this, pClusterList));
+
+    for (ClusterList::const_iterator iterI = pClusterList->begin(), iterIEnd = pClusterList->end(); iterI != iterIEnd; ++iterI)
+    {
+        const Cluster *const pDaughterCluster = *iterI;
+
+        // Identify whether cluster contacts need to be recalculated
+        if (!isFirstPass)
+        {
+            if (affectedClusters.end() == affectedClusters.find(pDaughterCluster))
+                continue;
+
+            ClusterContactMap::iterator pastEntryIter = clusterContactMap.find(pDaughterCluster);
+
+            if (clusterContactMap.end() != pastEntryIter)
+                clusterContactMap.erase(clusterContactMap.find(pDaughterCluster));
+        }
+
+        // Apply simple daughter selection cuts
+        if (!pDaughterCluster->GetAssociatedTrackList().empty())
+            continue;
+
+        if ((pDaughterCluster->GetNCaloHits() < m_minDaughterCaloHits) || (pDaughterCluster->GetHadronicEnergy() < m_minDaughterHadronicEnergy))
+            continue;
+
+        if (m_useOnlyPhotonLikeDaughters && !this->IsPhotonLike(pDaughterCluster))
+            continue;
+
+        const unsigned int daughterInnerLayer(pDaughterCluster->GetInnerPseudoLayer());
+
+        // Calculate the cluster contact information
+        for (ClusterList::const_iterator iterJ = pClusterList->begin(), iterJEnd = pClusterList->end(); iterJ != iterJEnd; ++iterJ)
+        {
+            const Cluster *const pParentCluster = *iterJ;
+
+            if (pDaughterCluster == pParentCluster)
+                continue;
+
+            // Parent selection cuts
+            if (!pParentCluster->GetAssociatedTrackList().empty())
+                continue;
+
+            if (pParentCluster->GetInnerPseudoLayer() > daughterInnerLayer + m_innerLayerTolerance)
+                continue;
+
+            if (pDaughterCluster->GetInitialDirection().GetCosOpeningAngle(pParentCluster->GetInitialDirection()) < m_minCosOpeningAngle)
+                continue;
+
+            if (!pParentCluster->IsPhotonFast(this->GetPandora()))
+                continue;
+
+            // Evaluate cluster contact properties
+            const ClusterContact clusterContact(this->GetPandora(), pDaughterCluster, pParentCluster, m_contactParameters);
+
+            if (this->PassesClusterContactCuts(clusterContact))
+            {
+                clusterContactMap[pDaughterCluster].push_back(clusterContact);
+            }
+        }
+    }
+    isFirstPass = false;
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool PhotonFragmentRemovalAlgorithm::IsPhotonLike(const Cluster *const pDaughterCluster) const
+{
+    if (pDaughterCluster->IsPhotonFast(this->GetPandora()))
+        return true;
+
+    const ClusterFitResult &clusterFitResult(pDaughterCluster->GetFitToAllHitsResult());
+
+    if ((PandoraContentApi::GetGeometry(*this)->GetHitTypeGranularity(pDaughterCluster->GetInnerLayerHitType()) <= FINE) &&
+        (pDaughterCluster->GetInnerPseudoLayer() < m_photonLikeMaxInnerLayer) &&
+        (clusterFitResult.IsFitSuccessful()) && (clusterFitResult.GetRadialDirectionCosine() > m_photonLikeMinDCosR) &&
+        (pDaughterCluster->GetShowerProfileStart(this->GetPandora()) < m_photonLikeMaxShowerStart) &&
+        (pDaughterCluster->GetShowerProfileDiscrepancy(this->GetPandora()) < m_photonLikeMaxProfileDiscrepancy))
+    {
+        return true;
+    }
+
+    return false;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool PhotonFragmentRemovalAlgorithm::PassesClusterContactCuts(const ClusterContact &clusterContact) const
+{
+    if (clusterContact.GetDistanceToClosestHit() > m_contactCutMaxDistance)
+        return false;
+
+    if ((clusterContact.GetNContactLayers() > m_contactCutNLayers) ||
+        (clusterContact.GetConeFraction1() > m_contactCutConeFraction1) ||
+        (clusterContact.GetCloseHitFraction1() > m_contactCutCloseHitFraction1) ||
+        (clusterContact.GetCloseHitFraction2() > m_contactCutCloseHitFraction2))
+    {
+        return true;
+    }
+
+    return false;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode PhotonFragmentRemovalAlgorithm::GetClusterMergingCandidates(const ClusterContactMap &clusterContactMap, const Cluster *&pBestParentCluster,
+    const Cluster *&pBestDaughterCluster) const
+{
+    float highestEvidence(m_minEvidence);
+    float highestEvidenceParentEnergy(0.);
+
+    for (ClusterContactMap::const_iterator iterI = clusterContactMap.begin(), iterIEnd = clusterContactMap.end(); iterI != iterIEnd; ++iterI)
+    {
+        const Cluster *const pDaughterCluster = iterI->first;
+
+        for (ClusterContactVector::const_iterator iterJ = iterI->second.begin(), iterJEnd = iterI->second.end(); iterJ != iterJEnd; ++iterJ)
+        {
+            ClusterContact clusterContact = *iterJ;
+
+            if (pDaughterCluster != clusterContact.GetDaughterCluster())
+                throw StatusCodeException(STATUS_CODE_FAILURE);
+
+            const float evidence(this->GetEvidenceForMerge(clusterContact));
+            const float parentEnergy(clusterContact.GetParentCluster()->GetHadronicEnergy());
+
+            if ((evidence > highestEvidence) || ((evidence == highestEvidence) && (parentEnergy > highestEvidenceParentEnergy)))
+            {
+                highestEvidence = evidence;
+                pBestDaughterCluster = pDaughterCluster;
+                pBestParentCluster = clusterContact.GetParentCluster();
+                highestEvidenceParentEnergy = parentEnergy;
+            }
+        }
+    }
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+float PhotonFragmentRemovalAlgorithm::GetEvidenceForMerge(const ClusterContact &clusterContact) const
+{
+    // Calculate a measure of the evidence that the daughter candidate cluster is a fragment of the parent candidate cluster:
+
+    // 1. Layers in contact
+    float contactEvidence(0.f);
+    if ((clusterContact.GetNContactLayers() > m_contactEvidenceNLayers) && (clusterContact.GetContactFraction() > m_contactEvidenceFraction))
+    {
+        contactEvidence = clusterContact.GetContactFraction();
+    }
+
+    // 2. Cone extrapolation
+    float coneEvidence(0.f);
+    if (clusterContact.GetConeFraction1() > m_coneEvidenceFraction1)
+    {
+        coneEvidence = clusterContact.GetConeFraction1();
+    }
+
+    // 3. Distance of closest approach
+    float distanceEvidence(0.f);
+    if (clusterContact.GetDistanceToClosestHit() < m_distanceEvidence1)
+    {
+        distanceEvidence = (m_distanceEvidence1 - clusterContact.GetDistanceToClosestHit()) / m_distanceEvidence1d;
+        distanceEvidence += m_distanceEvidenceCloseFraction1Multiplier * clusterContact.GetCloseHitFraction1();
+        distanceEvidence += m_distanceEvidenceCloseFraction2Multiplier * clusterContact.GetCloseHitFraction2();
+    }
+
+    return ((m_contactWeight * contactEvidence) + (m_coneWeight * coneEvidence) + (m_distanceWeight * distanceEvidence));
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode PhotonFragmentRemovalAlgorithm::GetAffectedClusters(const ClusterContactMap &clusterContactMap, const Cluster *const pBestParentCluster,
+    const Cluster *const pBestDaughterCluster, ClusterList &affectedClusters) const
+{
+    if (clusterContactMap.end() == clusterContactMap.find(pBestDaughterCluster))
+        return STATUS_CODE_FAILURE;
+
+    affectedClusters.clear();
+    for (ClusterContactMap::const_iterator iterI = clusterContactMap.begin(), iterIEnd = clusterContactMap.end(); iterI != iterIEnd; ++iterI)
+    {
+        // Store addresses of all clusters that were in contact with the newly deleted daughter cluster
+        if (iterI->first == pBestDaughterCluster)
+        {
+            for (ClusterContactVector::const_iterator iterJ = iterI->second.begin(), iterJEnd = iterI->second.end(); iterJ != iterJEnd; ++iterJ)
+            {
+                affectedClusters.insert(iterJ->GetParentCluster());
+            }
+            continue;
+        }
+
+        // Also store addresses of all clusters that contained either the parent or daughter clusters in their own ClusterContactVectors
+        for (ClusterContactVector::const_iterator iterJ = iterI->second.begin(), iterJEnd = iterI->second.end(); iterJ != iterJEnd; ++iterJ)
+        {
+            if ((iterJ->GetParentCluster() == pBestParentCluster) || (iterJ->GetParentCluster() == pBestDaughterCluster))
+            {
+                affectedClusters.insert(iterI->first);
+                break;
+            }
+        }
+    }
+
+    return STATUS_CODE_SUCCESS;
+}
+
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+StatusCode PhotonFragmentRemovalAlgorithm::ReadSettings(const TiXmlHandle xmlHandle)
+{
+    // Cluster contact parameters
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ConeCosineHalfAngle1", m_contactParameters.m_coneCosineHalfAngle1));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "CloseHitDistance1", m_contactParameters.m_closeHitDistance1));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "CloseHitDistance2", m_contactParameters.m_closeHitDistance2));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "MinCosOpeningAngle", m_contactParameters.m_minCosOpeningAngle));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "DistanceThreshold", m_contactParameters.m_distanceThreshold));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "NMaxPasses", m_nMaxPasses));
+
+    // Initial cluster candidate selection
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "MinDaughterCaloHits", m_minDaughterCaloHits));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "MinDaughterHadronicEnergy", m_minDaughterHadronicEnergy));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "InnerLayerTolerance", m_innerLayerTolerance));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "MinCosOpeningAngle", m_minCosOpeningAngle));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "UseOnlyPhotonLikeDaughters", m_useOnlyPhotonLikeDaughters));
+
+    // Photon-like cuts
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "PhotonLikeMaxInnerLayer", m_photonLikeMaxInnerLayer));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "PhotonLikeMinDCosR", m_photonLikeMinDCosR));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "PhotonLikeMaxShowerStart", m_photonLikeMaxShowerStart));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "PhotonLikeMaxProfileDiscrepancy", m_photonLikeMaxProfileDiscrepancy));
+
+    // Cluster contact cuts
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ContactCutMaxDistance", m_contactCutMaxDistance));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ContactCutNLayers", m_contactCutNLayers));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ContactCutConeFraction1", m_contactCutConeFraction1));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ContactCutCloseHitFraction1", m_contactCutCloseHitFraction1));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ContactCutCloseHitFraction2", m_contactCutCloseHitFraction2));
+
+    // Total evidence: Contact evidence
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ContactEvidenceNLayers", m_contactEvidenceNLayers));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ContactEvidenceFraction", m_contactEvidenceFraction));
+
+    // Cone evidence
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ConeEvidenceFraction1", m_coneEvidenceFraction1));
+
+    // Distance of closest approach evidence
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "DistanceEvidence1", m_distanceEvidence1));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "DistanceEvidence1d", m_distanceEvidence1d));
+
+    if (m_distanceEvidence1d < std::numeric_limits<float>::epsilon())
+        return STATUS_CODE_INVALID_PARAMETER;
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "DistanceEvidenceCloseFraction1Multiplier", m_distanceEvidenceCloseFraction1Multiplier));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "DistanceEvidenceCloseFraction2Multiplier", m_distanceEvidenceCloseFraction2Multiplier));
+
+    // Evidence weightings
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ContactWeight", m_contactWeight));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "ConeWeight", m_coneWeight));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "DistanceWeight", m_distanceWeight));
+
+    PANDORA_RETURN_RESULT_IF_AND_IF(STATUS_CODE_SUCCESS, STATUS_CODE_NOT_FOUND, !=, XmlHelper::ReadValue(xmlHandle,
+        "MinEvidence", m_minEvidence));
+
+    return STATUS_CODE_SUCCESS;
+}
+
+} // namespace lc_content_fast

--- a/src/LCHelpers/SortingHelper.cc
+++ b/src/LCHelpers/SortingHelper.cc
@@ -81,7 +81,7 @@ bool SortingHelper::SortTracksByEnergy(const Track *const pLhs, const Track *con
 
 bool SortingHelper::SortHitsByRadiusToCentroid(const std::pair<const pandora::CaloHit *, float>& pLhs, const std::pair<const pandora::CaloHit *, float>& pRhs)
 {
-	return (pLhs.second > pRhs.second);
+	return (pLhs.second < pRhs.second);
 }
 
 } // namespace lc_content

--- a/src/LCHelpers/SortingHelper.cc
+++ b/src/LCHelpers/SortingHelper.cc
@@ -77,4 +77,11 @@ bool SortingHelper::SortTracksByEnergy(const Track *const pLhs, const Track *con
     return (pLhs->GetEnergyAtDca() > pRhs->GetEnergyAtDca());
 }
 
+//------------------------------------------------------------------------------------------------------------------------------------------
+
+bool SortingHelper::SortHitsByRadiusToCentroid(const std::pair<const pandora::CaloHit *, float>& pLhs, const std::pair<const pandora::CaloHit *, float>& pRhs)
+{
+	return (pLhs.second > pRhs.second);
+}
+
 } // namespace lc_content


### PR DESCRIPTION
This pull request includes the following algorithm improvements:
1. In ClusterContact::HitDistanceComparison (used in MainFragmentRemoval, NeutralFragmentRemoval, and PhotonFragmentRemoval), for each pseudolayer, only n=6 parent hits closest to the pseudolayer centroid are used. "Fast" versions of NeutralFragmentRemoval and PhotonFragmentRemoval were added to take advantage of this.
2. Unnecessary unit vector calculations were removed from FragmentRemovalHelper::GetFractionOfHitsInCone().
3. In ConeClusteringAlgorithm::FindHitsInSameLayer(), the nearest neighbor hits found when searching for nearby clusters are kept so they can be checked by GetDistanceToHitInSameLayer(), in lieu of looping over all the nearby clusters' hits once again. Nearby clusters found only based on track proximity (with no hit proximity) will never pass this loop, so the loop is just skipped in that case.

Total speedup when tested with the CMS HGC at 140 pileup amounts to ~3 minutes, lowering the total time per event from ~13.5 minutes to ~10.5 minutes.
