### PR TITLE
Free memory from big containers

### DIFF
--- a/include/LCContentFast/CaloHitPreparationAlgorithmFast.h
+++ b/include/LCContentFast/CaloHitPreparationAlgorithmFast.h
@@ -9,12 +9,10 @@
 #define LC_CALO_HIT_PREPARATION_ALGORITHM_FAST_H 1
 
 #include "Pandora/Algorithm.h"
+#include "LCContentFast/KDTreeLinkerAlgoT.h"
 
 namespace lc_content_fast
 {
-
-template<typename, unsigned int> class KDTreeLinkerAlgo;
-template<typename, unsigned int> class KDTreeNodeInfoT;
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -99,8 +97,8 @@ private:
     unsigned int    m_mipNCellsForNearbyHit;            ///< Separation (in calo cells) for hits to be declared "nearby"
     unsigned int    m_mipMaxNearbyHits;                 ///< Max number of "nearby" hits for hit to be flagged as possible mip
 
-    std::vector<HitKDNode4D>   *m_hitNodes4D;           ///< nodes for the KD tree (used for filling)
-    HitKDTree4D                *m_hitsKdTree4D;         ///< the kd-tree itself, 4D in x,y,z,pseudolayer
+    std::vector<HitKDNode4D>   m_hitNodes4D;           ///< nodes for the KD tree (used for filling)
+    HitKDTree4D                m_hitsKdTree4D;         ///< the kd-tree itself, 4D in x,y,z,pseudolayer
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/include/LCContentFast/SoftClusterMergingAlgorithmFast.h
+++ b/include/LCContentFast/SoftClusterMergingAlgorithmFast.h
@@ -102,7 +102,7 @@ private:
      *  @return the index of the best parent cluster
      */
     int FindBestParentCluster(const pandora::ClusterVector &clusterVector, const HitToClusterMap &hitToClusterMap, QuickUnion &quickUnion,
-        const pandora::Cluster *const pDaughterCluster, const pandora::CaloHitList &daughterHits, float &closestDistance) const;
+        const pandora::Cluster *const pDaughterCluster, const pandora::CaloHitList &daughterHits, float &closestDistance);
 
     /**
      *  @brief  Whether a soft daughter candidate cluster can be merged with a parent a specified distance away
@@ -162,9 +162,9 @@ private:
     float                   m_maxClusterDistanceFine;               ///< Fine granularity max distance between parent and daughter clusters
     float                   m_maxClusterDistanceCoarse;             ///< Coarse granularity max distance between parent and daughter clusters
 
-    HitsToHitsCacheMap         *m_hitsToHitsCacheMap;               ///< To cache nearby hits retrieved from kd-tree
-    std::vector<HitKDNode3D>   *m_hitNodes3D;                       ///< nodes for the KD tree (used for filling)
-    HitKDTree3D                *m_hitsKdTree3D;                     ///< the kd-tree itself, 3D in x,y,z
+    HitsToHitsCacheMap         m_hitsToHitsCacheMap;               ///< To cache nearby hits retrieved from kd-tree
+    std::vector<HitKDNode3D>   m_hitNodes3D;                       ///< nodes for the KD tree (used for filling)
+    HitKDTree3D                m_hitsKdTree3D;                     ///< the kd-tree itself, 3D in x,y,z
 };
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/include/LCContentFast/SoftClusterMergingAlgorithmFast.h
+++ b/include/LCContentFast/SoftClusterMergingAlgorithmFast.h
@@ -9,14 +9,13 @@
 #define LC_SOFT_CLUSTER_MERGING_ALGORITHM_FAST_H 1
 
 #include "Pandora/Algorithm.h"
+#include "LCContentFast/KDTreeLinkerAlgoT.h"
 
 #include <unordered_map>
 
 namespace lc_content_fast
 {
 
-template<typename, unsigned int> class KDTreeLinkerAlgo;
-template<typename, unsigned int> class KDTreeNodeInfoT;
 class QuickUnion;
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/src/LCContentFast/CaloHitPreparationAlgorithmFast.cc
+++ b/src/LCContentFast/CaloHitPreparationAlgorithmFast.cc
@@ -26,18 +26,13 @@ CaloHitPreparationAlgorithm::CaloHitPreparationAlgorithm() :
     m_isolationMaxNearbyHits(2),
     m_mipLikeMipCut(5.f),
     m_mipNCellsForNearbyHit(2),
-    m_mipMaxNearbyHits(1),
-    m_hitNodes4D(new std::vector<HitKDNode4D>),
-    m_hitsKdTree4D(new HitKDTree4D)
-{
+    m_mipMaxNearbyHits(1){
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 CaloHitPreparationAlgorithm::~CaloHitPreparationAlgorithm()
 {
-    delete m_hitNodes4D;
-    delete m_hitsKdTree4D;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -68,7 +63,7 @@ StatusCode CaloHitPreparationAlgorithm::Run()
         return statusCodeException.GetStatusCode();
     }
 
-	m_hitsKdTree4D->clear();
+	m_hitsKdTree4D.clear();
 	
     return STATUS_CODE_SUCCESS;
 }
@@ -77,11 +72,12 @@ StatusCode CaloHitPreparationAlgorithm::Run()
 
 void CaloHitPreparationAlgorithm::InitializeKDTree(const CaloHitList *const pCaloHitList) 
 {
-    m_hitsKdTree4D->clear();
-    m_hitNodes4D->clear();
-    KDTreeTesseract hitsBoundingRegion4D = fill_and_bound_4d_kd_tree(this, *pCaloHitList, *m_hitNodes4D, true);
-    m_hitsKdTree4D->build(*m_hitNodes4D, hitsBoundingRegion4D);
-    m_hitNodes4D->clear();
+    m_hitsKdTree4D.clear();
+    m_hitNodes4D.clear();
+    KDTreeTesseract hitsBoundingRegion4D = fill_and_bound_4d_kd_tree(this, *pCaloHitList, m_hitNodes4D, true);
+    m_hitsKdTree4D.build(m_hitNodes4D, hitsBoundingRegion4D);
+    m_hitNodes4D.clear();
+    std::vector<HitKDNode4D>().swap(m_hitNodes4D);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -167,7 +163,7 @@ unsigned int CaloHitPreparationAlgorithm::IsolationCountNearbyHits(unsigned int 
     KDTreeTesseract searchRegionHits = build_4d_kd_search_region(pCaloHit, searchDistance, searchDistance, searchDistance, searchLayer);
 
     std::vector<HitKDNode4D> found;
-    m_hitsKdTree4D->search(searchRegionHits, found);
+    m_hitsKdTree4D.search(searchRegionHits, found);
 
     for (const auto &hit : found)
     {
@@ -208,7 +204,7 @@ unsigned int CaloHitPreparationAlgorithm::MipCountNearbyHits(unsigned int search
     KDTreeTesseract searchRegionHits = build_4d_kd_search_region(pCaloHit, searchDistance, searchDistance, searchDistance, searchLayer);
 
     std::vector<HitKDNode4D> found;
-    m_hitsKdTree4D->search(searchRegionHits, found);
+    m_hitsKdTree4D.search(searchRegionHits, found);
 
     for (const auto &hit : found)
     {

--- a/src/LCContentFast/CaloHitPreparationAlgorithmFast.cc
+++ b/src/LCContentFast/CaloHitPreparationAlgorithmFast.cc
@@ -68,6 +68,8 @@ StatusCode CaloHitPreparationAlgorithm::Run()
         return statusCodeException.GetStatusCode();
     }
 
+	m_hitsKdTree4D->clear();
+	
     return STATUS_CODE_SUCCESS;
 }
 

--- a/src/LCContentFast/ConeClusteringAlgorithmFast.cc
+++ b/src/LCContentFast/ConeClusteringAlgorithmFast.cc
@@ -113,8 +113,10 @@ StatusCode ConeClusteringAlgorithm::Run()
     //reset our kd trees and maps if everything turned out well
     m_tracksKdTree.clear();
     m_hitsKdTree.clear();
-    m_hitsToClusters.clear();
-    m_tracksToClusters.clear();
+	m_hitsToClusters.clear();
+	std::unordered_map<const pandora::CaloHit*, const pandora::Cluster*>().swap(m_hitsToClusters);
+	m_tracksToClusters.clear();
+	std::unordered_map<const pandora::Track*, const pandora::Cluster*>().swap(m_tracksToClusters);
 
     return STATUS_CODE_SUCCESS;
 }

--- a/src/LCContentFast/ConeClusteringAlgorithmFast.cc
+++ b/src/LCContentFast/ConeClusteringAlgorithmFast.cc
@@ -134,6 +134,7 @@ StatusCode ConeClusteringAlgorithm::InitializeKDTrees(const TrackList *const pTr
         KDTreeCube tracksBoundingRegion = fill_and_bound_3d_kd_tree(this, *pTrackList, m_trackNodes);
         m_tracksKdTree.build(m_trackNodes,tracksBoundingRegion);
         m_trackNodes.clear();
+		std::vector<TrackKDNode>().swap(m_trackNodes);
     }
 
     // make sure the hit kd tree is ready
@@ -142,6 +143,7 @@ StatusCode ConeClusteringAlgorithm::InitializeKDTrees(const TrackList *const pTr
     KDTreeTesseract hitsBoundingRegion = fill_and_bound_4d_kd_tree(this,*pCaloHitList,m_hitNodes);
     m_hitsKdTree.build(m_hitNodes,hitsBoundingRegion);
     m_hitNodes.clear();
+	std::vector<HitKDNode>().swap(m_hitNodes);
 
     return STATUS_CODE_SUCCESS;
 }

--- a/src/LCContentFast/SoftClusterMergingAlgorithmFast.cc
+++ b/src/LCContentFast/SoftClusterMergingAlgorithmFast.cc
@@ -36,10 +36,7 @@ SoftClusterMergingAlgorithm::SoftClusterMergingAlgorithm() :
     m_closestDistanceCut2(250.f),
     m_innerLayerCut2(40),
     m_maxClusterDistanceFine(100.f),
-    m_maxClusterDistanceCoarse(250.f),
-    m_hitsToHitsCacheMap(new HitsToHitsCacheMap),
-    m_hitNodes3D(new std::vector<HitKDNode3D>),
-    m_hitsKdTree3D(new HitKDTree3D)
+    m_maxClusterDistanceCoarse(250.f)
 {
 }
 
@@ -47,9 +44,6 @@ SoftClusterMergingAlgorithm::SoftClusterMergingAlgorithm() :
 
 SoftClusterMergingAlgorithm::~SoftClusterMergingAlgorithm()
 {
-    delete m_hitsToHitsCacheMap;
-    delete m_hitNodes3D;
-    delete m_hitsKdTree3D;
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -90,6 +84,10 @@ StatusCode SoftClusterMergingAlgorithm::Run()
             quickUnion.Unite(index, parentIndex);
         }
     }
+	
+	m_hitsKdTree3D.clear();
+	m_hitsToHitsCacheMap.clear();
+	HitsToHitsCacheMap().swap(m_hitsToHitsCacheMap);
 
     return STATUS_CODE_SUCCESS;
 }
@@ -152,12 +150,12 @@ void SoftClusterMergingAlgorithm::GetInputCaloHits(const ClusterVector &clusterV
 
 void SoftClusterMergingAlgorithm::InitializeKDTree(const CaloHitList *const pCaloHitList) 
 {
-    m_hitsToHitsCacheMap->clear();
-    m_hitsKdTree3D->clear();
-    m_hitNodes3D->clear();
-    KDTreeCube hitsBoundingRegion3D = fill_and_bound_3d_kd_tree(this, *pCaloHitList, *m_hitNodes3D, true);
-    m_hitsKdTree3D->build(*m_hitNodes3D, hitsBoundingRegion3D);
-    m_hitNodes3D->clear();
+    m_hitsToHitsCacheMap.clear();
+    m_hitsKdTree3D.clear();
+    m_hitNodes3D.clear();
+    KDTreeCube hitsBoundingRegion3D = fill_and_bound_3d_kd_tree(this, *pCaloHitList, m_hitNodes3D, true);
+    m_hitsKdTree3D.build(m_hitNodes3D, hitsBoundingRegion3D);
+    m_hitNodes3D.clear();
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------
@@ -201,7 +199,7 @@ bool SoftClusterMergingAlgorithm::IsSoftCluster(const Cluster *const pDaughterCl
 //------------------------------------------------------------------------------------------------------------------------------------------
 
 int SoftClusterMergingAlgorithm::FindBestParentCluster(const ClusterVector &clusterVector, const HitToClusterMap &hitToClusterMap,
-    QuickUnion &quickUnion, const Cluster *const pDaughterCluster, const CaloHitList &daughterHits, float &closestDistance) const
+    QuickUnion &quickUnion, const Cluster *const pDaughterCluster, const CaloHitList &daughterHits, float &closestDistance)
 {
     int bestParentIndex(-1);
     closestDistance = std::numeric_limits<float>::max();
@@ -217,9 +215,9 @@ int SoftClusterMergingAlgorithm::FindBestParentCluster(const ClusterVector &clus
         const CartesianVector &positionVectorI(pCaloHitI->GetPositionVector());
         CaloHitList nearby_hits;
 
-        if (m_hitsToHitsCacheMap->count(pCaloHitI))
+        if (m_hitsToHitsCacheMap.count(pCaloHitI))
         {
-            const auto range = m_hitsToHitsCacheMap->equal_range(pCaloHitI);
+            const auto range = m_hitsToHitsCacheMap.equal_range(pCaloHitI);
 
             for (auto rangeIter = range.first; rangeIter != range.second; ++rangeIter)
                 nearby_hits.insert(rangeIter->second);
@@ -228,11 +226,11 @@ int SoftClusterMergingAlgorithm::FindBestParentCluster(const ClusterVector &clus
         {
             KDTreeCube searchRegionHits = build_3d_kd_search_region(pCaloHitI, searchDistance, searchDistance, searchDistance);
             std::vector<HitKDNode3D> found;
-            m_hitsKdTree3D->search(searchRegionHits, found);
+            m_hitsKdTree3D.search(searchRegionHits, found);
 
             for (const auto &hit : found)
             {
-                m_hitsToHitsCacheMap->emplace(pCaloHitI, hit.data);
+                m_hitsToHitsCacheMap.emplace(pCaloHitI, hit.data);
                 nearby_hits.insert(hit.data);
             }
         }

--- a/src/LCContentFast/SoftClusterMergingAlgorithmFast.cc
+++ b/src/LCContentFast/SoftClusterMergingAlgorithmFast.cc
@@ -156,6 +156,7 @@ void SoftClusterMergingAlgorithm::InitializeKDTree(const CaloHitList *const pCal
     KDTreeCube hitsBoundingRegion3D = fill_and_bound_3d_kd_tree(this, *pCaloHitList, m_hitNodes3D, true);
     m_hitsKdTree3D.build(m_hitNodes3D, hitsBoundingRegion3D);
     m_hitNodes3D.clear();
+	std::vector<HitKDNode3D>().swap(m_hitNodes3D);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
1. kd-trees are cleared at the _end_ of each algorithm's run.
2. Big containers of hits or clusters (vector, unordered_map, etc.) have their memory freed at the end of each algorithm's run using swap().

Memory use before these changes (5 140PU events, full reco with CMS HGC on lxplus):
![memory_5evt_old](https://cloud.githubusercontent.com/assets/4672808/6605358/4c343a80-c7fd-11e4-9a65-c42f80016339.png)

Memory use after these changes (same 5 140PU events, full reco with CMS HGC on lxplus):
![memory_5evt_new](https://cloud.githubusercontent.com/assets/4672808/6605365/55248456-c7fd-11e4-8e1f-353f03aafed6.png)

Peak memory reduction is about 300MB.
